### PR TITLE
Updates rest-client. Version 1.8.0 has some security improvements.

### DIFF
--- a/verifalia.gemspec
+++ b/verifalia.gemspec
@@ -17,15 +17,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.extra_rdoc_files = ['README.md', 'LICENSE.md']
   spec.rdoc_options = ['--line-numbers', '--inline-source', '--title', '--main', 'README.md']
-  
+
   spec.add_dependency('builder', '>= 2.1.2')
-  spec.add_dependency('rest-client', '~> 1.7.2')
-  
+  spec.add_dependency('rest-client', '~> 1.8.0')
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  
-  
+
+
 end


### PR DESCRIPTION
> CHANGELOG FOR REST-CLIENT FROM 1.7.3 TO 1.8.0
> 
> Security: implement standards compliant cookie handling by adding a dependency on http-cookie. This breaks compatibility, but was necessary to address a session fixation / cookie disclosure vulnerability. (#369 / CVE-2015-1820)
> Previously, any Set-Cookie headers found in an HTTP 30x response would be sent to the redirection target, regardless of domain. Responses now expose a cookie jar and respect standards compliant domain / path flags in Set-Cookie headers.
