### PR TITLE
Revert "Fixes #5, Updated EmailValidations#query"

### DIFF
--- a/lib/rest/email_validations.rb
+++ b/lib/rest/email_validations.rb
@@ -47,7 +47,7 @@ module Verifalia
       #
       def query
         raise ArgumentError, 'You must call verify first or supply and uniqueId' unless @unique_id
-        unless is_job_completed?
+        unless @response
           begin
             r = @resource[@unique_id].get
             @response = JSON.parse(r)
@@ -80,11 +80,12 @@ module Verifalia
       end
 
       ##
-      # query and check if the Email validation job is processed. In order to use
+      # Check if the Email validation entity is completed processed. In order to use
       # this method you need to supply unique_id during initialization or call verify first.
+      #
       def completed?
-        query 
-        is_job_completed?
+        query_progress = query["progress"]
+        query_progress["noOfTotalEntries"] == query_progress["noOfCompletedEntries"]
       end
 
       def error
@@ -92,16 +93,6 @@ module Verifalia
       end
 
       private
-      
-        ## 
-        # Check if the Email validation job in progress, implementation is slightly different than 
-        # completed? method, this does not query API unlike completed? method  
-        def is_job_completed?
-          return false if @response.nil?
-          query_progress = @response["progress"]
-          query_progress["noOfTotalEntries"] == query_progress["noOfCompletedEntries"]
-        end
-
         def compute_error(e)
           unless e.is_a? RestClient::Exception
             @error = :internal_server_error

--- a/spec/rest/email_validations_spec.rb
+++ b/spec/rest/email_validations_spec.rb
@@ -141,44 +141,6 @@ describe Verifalia::REST::EmailValidations do
         end
 
       end
-
-      context "will refresh data - on consecutive calls" do 
-        let(:incompleted_query) do
-          { "progress"=> { "noOfTotalEntries" => 1, "noOfCompletedEntries" => 0 } }
-        end
-
-        let(:completed_query) do
-          { "progress"=> { "noOfTotalEntries" => 1, "noOfCompletedEntries" => 1 } }
-        end
-
-        before(:each) do 
-          @email_validations.instance_variable_set('@unique_id', 'fake')
-        end
-
-        it "should call the api when not completed" do
-          @email_validations.instance_variable_set('@response', incompleted_query)
-          request = double()
-          expect(resource).to receive(:[]).with('fake').and_return(request)
-          expect(request).to receive(:get).with(content_type: :json).and_return(incompleted_query.to_json)
-          expect(JSON).to receive(:parse).and_return(incompleted_query)
-          expect(@email_validations.completed?).to be false
-        end
-
-        it "should verify if completed after update results from the api" do
-          @email_validations.instance_variable_set('@response', incompleted_query)
-          request = double()
-          expect(resource).to receive(:[]).with('fake').and_return(request)
-          expect(request).to receive(:get).with(content_type: :json).and_return(completed_query.to_json)
-          expect(JSON).to receive(:parse).and_return(completed_query)
-          expect(@email_validations.completed?).to be true
-        end
-
-        it "should not call the api when completed" do
-          @email_validations.instance_variable_set('@response', completed_query)
-          expect(resource).to_not receive(:[])
-          expect(@email_validations.completed?).to be true
-        end
-      end
     end
 
     describe '#completed?' do
@@ -186,18 +148,12 @@ describe Verifalia::REST::EmailValidations do
         { "progress"=> { "noOfTotalEntries" => 1, "noOfCompletedEntries" => 1 } }
       end
       let(:incompleted_query) do
-        { "progress"=> { "noOfTotalEntries" => 1, "noOfCompletedEntries" => 0 } }
+        { "progress"=> { "noOfTotalEntries" => 0, "noOfCompletedEntries" => 1 } }
       end
 
       it 'should return true if completed' do
-        expect(@email_validations.instance_variable_set('@response', completed_query))
         expect(@email_validations).to receive(:query).and_return(completed_query)
         expect(@email_validations.completed?).to be true
-      end
-
-      it 'should return false if @response is not initialized' do
-        expect(@email_validations).to receive(:query).and_return(completed_query)
-        expect(@email_validations.completed?).to be false
       end
 
       it 'should return false if not completed' do


### PR DESCRIPTION
So, the https://github.com/verifalia/verifalia-ruby-sdk/pull/10 PR was open since ever and I decided to merge it. Surprisingly the tests are breaking and I have no idea why. I can't look at this right now, so, I'll revert it. 

I also noticed that the builder is no longer working in this project. Unfortunately, I don't have the permissions to fix it. 